### PR TITLE
Should now build with iRODS >4.18.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -14,6 +14,11 @@
 # You should have received a copy of the GNU General Public License along with
 # this program. If not, see <http://www.gnu.org/licenses>
 
+ACLOCAL_AMFLAGS= -I m4
+
+AM_CPPFLAGS = $(IRODS_CPPFLAGS)
+AM_LDFLAGS  = $(IRODS_LDFLAGS)
+LIBS       += $(IRODS_LIBS)
 bin_PROGRAMS = tears
 
 tears_SOURCES = tears.c

--- a/configure.ac
+++ b/configure.ac
@@ -19,14 +19,20 @@ this program. If not, see <http://www.gnu.org/licenses>])
 dnl Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.68])
-AC_INIT([tears], [1.1], [aw7+github@sanger.ac.uk])
+
+AC_INIT([tears], [1.2], [aw7+github@sanger.ac.uk])
+AC_USE_SYSTEM_EXTENSIONS
 
 AM_INIT_AUTOMAKE([-Wall foreign])
 
 AC_PROG_CC
 AC_PROG_CC_C99
 AC_PROG_CC_C_O
+AC_PROG_CXX
+
 AC_LANG([C])
+
+AC_CONFIG_MACRO_DIR([m4])
 
 AC_ARG_ENABLE(debug,
     AS_HELP_STRING([--enable-debug],[use compiler debug flags (default no)]),
@@ -62,70 +68,7 @@ echo "Required function not found, giving up."
 exit 1
 ])dnl
 
-AC_CHECK_LIB([gssapi_krb5], [gss_acquire_cred])
-AC_CHECK_LIB([pthread], [pthread_kill])
-
-dnl Save the original values to restore between tests
-CPPFLAGS_ORIG=${CPPFLAGS}
-LDFLAGS_ORIG=${LDFLAGS}
-LIBS_ORIG=${LIBS}
-
-dnl Look for iRODS
-IRODS_HOME=
-AC_ARG_WITH([irods],
-  [AS_HELP_STRING([--with-irods],
-    [Specify the location of a run-in-place iRODS installation (default: /usr/local/lib/irods)])],
-  [AS_IF(
-    [test "x$with_irods" = "xno"],
-      [AC_MSG_FAILURE([iRODS is required to build tears])],
-    [test "x$with_irods" = "xyes"],
-      [AC_MSG_NOTICE([using default iRODS location])
-       IRODS_HOME="/usr/local/lib/irods"
-       IS_PACKAGED_INSTALL="no"],
-     [IRODS_HOME="$with_irods"
-      IS_PACKAGED_INSTALL="no"])],
-  [IS_PACKAGED_INSTALL="yes"])
-  
-AC_SUBST(IRODS_HOME)
-
-dnl Begin iRODS 3.3.x
-
-dnl iRODS 3.3.x supports only run-in-place (RIP) installation.  Its
-dnl headers and shared libraries are in non-standard places, which may
-dnl be determined relative to IRODS_HOME.
-IRODS3_CPPFLAGS=\
-"-I${IRODS_HOME}/lib/api/include \
--I${IRODS_HOME}/lib/core/include \
--I${IRODS_HOME}/lib/md5/include \
--I${IRODS_HOME}/lib/sha1/include \
--I${IRODS_HOME}/server/core/include \
--I${IRODS_HOME}/server/drivers/include \
--I${IRODS_HOME}/server/icat/include \
--I${IRODS_HOME}/server/re/include"
-IRODS3_LDFLAGS="-L${IRODS_HOME}/lib/core/obj"
-
-CPPFLAGS="$CPPFLAGS_ORIG ${IRODS3_CPPFLAGS}"
-LDFLAGS="$LDFLAGS_ORIG ${IRODS3_LDFLAGS}"
-LIBS="${LIBS_ORIG}"
-
-HAVE_IRODS3=no
-
-AC_RUN_IFELSE(
-  [AC_LANG_PROGRAM([
-#include <string.h>
-#include <rodsVersion.h>
-], [
-#if defined (RODS_REL_VERSION)
-  return strncmp("rods3.3", RODS_REL_VERSION, 7);
-#else
-  exit(-1);
-#endif
-])],
-  [ AC_MSG_NOTICE([detected iRODS 3.3.x])
-   [HAVE_IRODS3=yes]
-   AC_CHECK_LIB([RodsAPIs], [getRodsEnvFileName], [],
-     [AC_MSG_ERROR([unable to find the iRODS library libRodsAPIs])])],
-    [AC_MSG_ERROR([test iRODS program failed with IRODS_HOME=${IRODS_HOME}])])
+AX_WITH_IRODS
 
 AC_CONFIG_SRCDIR([tears.c])
 AC_CONFIG_HEADERS([tears_config.h])

--- a/m4/ax_with_irods.m4
+++ b/m4/ax_with_irods.m4
@@ -1,0 +1,210 @@
+#
+# SYNOPSIS
+#
+#   AX_WITH_IRODS()
+#
+# DESCRIPTION
+#
+#   This macro searches for the header files and libraries of an iRODS
+#   (https://irods.org) installation.  If --with-irods is specified
+#   without argument, or as --with-irods=yes, a packaged (.deb or
+#   .rpm) installation is assumed and the default system paths will be
+#   searched.  If --with-irods=DIR is specified, a run-in-place iRODS
+#   installation will be searched for in DIR.  If --without-irods is
+#   specified, any iRODS installations present will be ignored.
+#
+#   The system header and library paths will be used for run-in-place
+#   iRODS installation dependencies, in preference to the those
+#   dependencies provided by iRODS in its 'externals' directory
+#   because the latter cannot be determined reliably.
+#
+#   The iRODS versions are supported are 3.3.x and >= 4.1.8.
+#
+#   The macro defines the symbol HAVE_IRODS if the library is found
+#   and the following output variables are set with AC_SUBST:
+#
+#     IRODS_CPPFLAGS
+#     IRODS_LDFLAGS
+#     IRODS_LIBS
+#
+#   You can use them like this in Makefile.am:
+#
+#      AM_CPPFLAGS       = $(IRODS_CPPFLAGS)
+#      AM_LDFLAGS        = $(IRODS_LDFLAGS)
+#      library_la_LIBADD = $(IRODS_LIBS)
+#      program_LDADD     = $(IRODS_LIBS)
+#
+# LICENSE
+#
+# Copyright (C) 2016, Genome Research Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+AC_DEFUN([AX_WITH_IRODS], [
+   IRODS_HOME=
+   IRODS_CPPFLAGS=
+   IRODS_LDFLAGS=
+   IRODS_LIBS=
+
+   saved_CPPFLAGS="$CPPFLAGS"
+   saved_LDFLAGS="$LDFLAGS"
+   saved_LIBS="$LIBS"
+
+   AC_ARG_WITH([irods],
+       [AS_HELP_STRING([--with-irods[[=DIR]]], [Enable iRODS support])], [
+           AS_IF([test "x$with_irods" != "xno"], [
+
+               AC_CHECK_LIB([rt], [timer_create])
+               AC_CHECK_LIB([m], [log10])
+               AC_CHECK_LIB([dl], [dlopen])
+               AC_CHECK_LIB([pthread], [pthread_kill])
+               AC_CHECK_LIB([gssapi_krb5], [gss_acquire_cred])
+               AC_CHECK_LIB([jansson], [json_unpack], [],
+                  [AC_MSG_ERROR([unable to find libjannson])])
+
+               IRODS4_LIBS="-lirods_client -lirods_client_api_table -lirods_client_api -lirods_client_core \
+	       -lboost_program_options -lboost_filesystem \
+    	       -lboost_regex -lboost_chrono -lboost_thread -lboost_system"
+
+               AS_IF([test "x$with_irods" = "xyes"], [
+                   AC_MSG_CHECKING([for packaged iRODS])
+
+                   CPPFLAGS="-I/usr/include/irods $CPPFLAGS"
+                   LDFLAGS="-Wl,-E -L/usr/lib/irods/externals $LDFLAGS"
+
+                   AC_RUN_IFELSE([AC_LANG_PROGRAM([
+                        #include <rodsVersion.h>
+                      ], [
+                        #if IRODS_VERSION_INTEGER >= 4001008
+                        return 0;
+                        #else
+                        exit(-1);
+                        #endif
+                      ])
+                   ], [
+                       AC_MSG_RESULT([yes])
+                       AC_DEFINE([HAVE_IRODS], [1], [iRODS >= 4.1.8])
+
+                       LDFLAGS="$IRODS4_RIP_LDFLAGS $LDFLAGS"
+                       LIBS="$IRODS4_LIBS $LIBS -lstdc++"
+
+                       AC_CHECK_LIB([crypto], [EVP_EncryptUpdate], [],
+                          [AC_MSG_ERROR([unable to find libcrypto])])
+
+                       AC_CHECK_LIB([ssl], [SSL_get_error], [],
+                          [AC_MSG_ERROR([unable to find libssl])])
+
+                        AC_CHECK_LIB([RodsAPIs], [getRodsEnv], [],
+                          [AC_MSG_ERROR([unable to find libRodsAPIs])],
+                          [-lirods_client_plugins])
+
+                        AC_CHECK_LIB([irods_client_plugins],
+                          [operation_rule_execution_manager_factory], [],
+                          [AC_MSG_ERROR([unable to find libirods_client_plugins])],
+                          [-lRodsAPIs])
+                  ], [
+                       AC_MSG_RESULT([no])
+                   ])
+               ], [
+                   IRODS_HOME="$with_irods"
+
+                   IRODS_RIP_CPPFLAGS="-I$IRODS_HOME/lib/api/include \
+-I$IRODS_HOME/lib/core/include -I$IRODS_HOME/lib/md5/include \
+-I$IRODS_HOME/lib/sha1/include -I$IRODS_HOME/server/core/include \
+-I$IRODS_HOME/server/drivers/include -I$IRODS_HOME/server/icat/include \
+-I$IRODS_HOME/server/re/include"
+
+                   IRODS3_RIP_LDFLAGS="-L$IRODS_HOME/lib/core/obj"
+                   IRODS4_RIP_LDFLAGS="-Wl,-E -L$IRODS_HOME/lib/core/obj \
+-L$IRODS_HOME/lib/development_libraries"
+
+                   CPPFLAGS="$IRODS_RIP_CPPFLAGS $CPPFLAGS"
+
+                   AC_MSG_CHECKING([for iRODS 3.3.x])
+                   AC_RUN_IFELSE([AC_LANG_PROGRAM([
+                        #include <string.h>
+                        #include <rodsVersion.h>
+                      ], [
+                        #if defined (RODS_REL_VERSION)
+                        return strncmp("rods3.3", RODS_REL_VERSION, 7);
+                        #else
+                        exit(-1);
+                        #endif
+                      ])
+                   ], [
+                       AC_MSG_RESULT([yes])
+                       AC_DEFINE([HAVE_IRODS], [1], [iRODS 3.3.x])
+
+                       LDFLAGS="$IRODS3_RIP_LDFLAGS $LDFLAGS"
+
+                       AC_CHECK_LIB([RodsAPIs], [getRodsEnv], [],
+                          [AC_MSG_ERROR([unable to find libRodsAPIs])])
+                   ], [
+                       AC_MSG_RESULT([no])
+                   ])
+
+                   AC_MSG_CHECKING([for iRODS >= 4.1.8])
+                   AC_RUN_IFELSE([AC_LANG_PROGRAM([
+                        #include <rodsVersion.h>
+                      ], [
+                        #if IRODS_VERSION_INTEGER >= 4001008
+                        return 0;
+                        #else
+                        exit(-1);
+                        #endif
+                      ])
+                   ], [
+                       AC_MSG_RESULT([yes])
+                       AC_DEFINE([HAVE_IRODS], [1], [iRODS >= 4.1.8])
+
+                       LDFLAGS="$IRODS4_RIP_LDFLAGS $LDFLAGS"
+                       LIBS="$IRODS4_LIBS $LIBS -lstdc++"
+
+                       AC_CHECK_LIB([crypto], [EVP_EncryptUpdate], [],
+                          [AC_MSG_ERROR([unable to find libcrypto])])
+
+                       AC_CHECK_LIB([ssl], [SSL_get_error], [],
+                          [AC_MSG_ERROR([unable to find libssl])])
+
+                       AC_CHECK_LIB([RodsAPIs], [getRodsEnv], [],
+                          [AC_MSG_ERROR([unable to find libRodsAPIs])],
+                          [-lirods_client_plugins])
+
+                       AC_CHECK_LIB([irods_client_plugins],
+                          [operation_rule_execution_manager_factory], [],
+                          [AC_MSG_ERROR([unable to find libirods_client_plugins])],
+                          [-lRodsAPIs])
+                   ], [
+                       AC_MSG_RESULT([no])
+                   ])
+               ])
+
+               IRODS_CPPFLAGS="$CPPFLAGS"
+               IRODS_LDFLAGS="$LDFLAGS"
+               IRODS_LIBS="$LIBS"
+
+               CPPFLAGS="$saved_CPPFLAGS"
+               LDFLAGS="$saved_LDFLAGS"
+               LIBS="$saved_LIBS"
+
+               unset saved_CPPFLAGS
+               unset saved_LDFLAGS
+               unset saved_LIBS
+
+               AC_SUBST([IRODS_HOME])
+               AC_SUBST([IRODS_CPPFLAGS])
+               AC_SUBST([IRODS_LDFLAGS])
+               AC_SUBST([IRODS_LIBS])
+           ])
+   ])
+])


### PR DESCRIPTION
C code added for the differences and a M4 macro file added to work with different iRODS build versions.
