### PR TITLE
Add a time-out option

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,17 +3,20 @@ Stream files to and from iRODS.
 
 tears either reads from stdin and writes a file to iRODS or reads a file from iRODS and writes to stdout.  Basic usage for writing is:
 
-file_making_program | tears -w /path/to/irods/file
+`file_making_program | tears -w /path/to/irods/file`
 
 or for reading:
 
-tears /path/to/irods/file | file_receiving_program
+`tears /path/to/irods/file | file_receiving_program`
 
 Two things to note.  Firstly, tears will try to pick the best iRODS host to read or write from.  This can cause authentication problems and can be switched off by using the -d option.  Secondly, the iRODS file can be in the form of a URI (proposed [here](https://github.com/samtools/htslib/issues/229)).  The URI is of the form:
 
-irods://[irodsUserName%23irodsZone@][irodsHost][:irodsPort]/collection_path/data_object
+_irods://[irodsUserName%23irodsZone@][irodsHost][:irodsPort]/collection_path/data_object_
 
+### Build
 
+`autoreconf -i -f`
 
+`./configure --with-irods`
 
-
+`make`

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 dnl                                             -*- Autoconf -*-
 AC_COPYRIGHT([
-Copyright (c) 2015-2016, 2018 Genome Research Ltd.
+Copyright (c) 2015-2016, 2018-2019 Genome Research Ltd.
 Author: Andrew Whitwham <aw7+github@sanger.ac.uk>
 
 This file is part of tears.
@@ -20,7 +20,7 @@ dnl Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.68])
 
-AC_INIT([tears], [1.2.4], [aw7+github@sanger.ac.uk], [tears], [https://github.com/whitwham/tears])
+AC_INIT([tears], [1.3], [aw7+github@sanger.ac.uk], [tears], [https://github.com/whitwham/tears])
 AC_USE_SYSTEM_EXTENSIONS
 
 AM_INIT_AUTOMAKE([-Wall foreign])


### PR DESCRIPTION
Add a time-out option (-t minutes) after which the open iRODS object will be closed and then reopened again.  The write (or read) will then continue from where it left off.

This is an attempt to work around an iRODS socket/pipe failure that we have observed in some of the longer running (an hour or more) write operations.